### PR TITLE
Implemented AI for Flight Group Alpha ships.

### DIFF
--- a/DataPad.a4dbbf.ttslua
+++ b/DataPad.a4dbbf.ttslua
@@ -423,7 +423,7 @@ masterShipDB[35]={['name']='A-Wing',['Hull']=2,['Shield']=2,['size']='small',['a
 masterShipDB[36]={['name']='Fang Fighter',['Hull']=4,['Shield']=0,['size']='small',['agi']=3,['XWS']='fangfighter', ['Fac']={[3]=true}, ['arcs']={'front'},
                             ['moveSet']={'wtl1','wtr1','rtl2t','btl2','bbl2','bs2','bbr2','btr2','rtr2t','wtl3','wbl3','bs3','wbr3','wtr3','ws4','rk4','ws5'}}
 --masterShipDB[37]={['name']='',['Shield']=3,['size']='small',['agi']=1,['XWS']='', ['Fac']={[1]=true}}
-masterShipDB[38]={['name']='Z-95 Headhunter',['Hull']=2,['Shield']=2,['size']='small',['agi']=2,['XWS']='z95af4headhunter', ['Fac']={[1]=true,[3]=true}, ['arcs']={'front'},
+masterShipDB[38]={['name']='Z-95 Headhunter',['Hull']=2,['Shield']=2,['size']='small',['agi']=2,['XWS']='z95af4headhunter', ['Fac']={[1]=true}, ['arcs']={'front'},
                             ['moveSet']={'wbl1','bs1','wbr1','wtl2','bbl2','bs2','bbr2','wtr2','wtl3','wbl3','bs3','wbr3','wtr3','rk3','ws4','rk4'}}
 masterShipDB[39]={['name']='M12-L Kimogila',['Hull']=7,['Shield']=2,['size']='medium',['agi']=2,['XWS']='m12lkimogilafighter', ['Fac']={[3]=true}, ['arcs']={'front'},
                             ['moveSet']={'rtl1','wbl1','bs1','wbr1','rtr1','wtl2','bbl2','bs2','bbr2','wtr2','wtl3','wbl3','bs3','wbr3','wtr3','rk4'}}
@@ -623,6 +623,9 @@ masterShipDB[71]={
     mesh = 'https://raw.githubusercontent.com/eirikmun/TTS_X-Wing2.0/master/assets/ships/Small/FO_Tie_Ba/TieBa.obj',
     moveSet = {'btl1','bbl1','bbr1','btr1','wtl2','bbl2','bs2','bbr2','wtr2','wtl3','wbl3','bs3','wbr3','wtr3','rbl2s','rbr2s','bs4','ws5','rk5'}
 }
+
+masterShipDB[74]={['name']='Z-95 Headhunter',['Hull']=2,['Shield']=2,['size']='small',['agi']=2,['XWS']='z95af4headhunter', ['Fac']={[3]=true}, ['arcs']={'front'},
+                            ['moveSet']={'wbl1','bs1','wbr1','wtl2','bbl2','bs2','bbr2','wtr2','wtl3','wbl3','bs3','wbr3','wtr3','rk3','ws4','rk4'}}
 
 --w7ship
 --[[masterShipDB[80]={
@@ -1905,15 +1908,15 @@ masterPilotDB[168]={
     actSet = {'F','TL','BR'}
 }
 
-masterPilotDB[169]={['name']="N'dru Suhlak",['Faction']= 3,['ship_type']=38,['cost']=30,['slot']={21, 1, 6, 13, 14},['Shield']=2,
+masterPilotDB[169]={['name']="N'dru Suhlak",['Faction']= 3,['ship_type']=74,['cost']=30,['slot']={21, 1, 6, 13, 14},['Shield']=2,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_169.png',['init']=4,['actSet']={'F','TL','BR'}}
-masterPilotDB[170]={['name']="Kaa'to Leeachos",['Faction']= 3,['ship_type']=38,['cost']=27,['slot']={21, 1, 6, 13, 14},['Shield']=2,
+masterPilotDB[170]={['name']="Kaa'to Leeachos",['Faction']= 3,['ship_type']=74,['cost']=27,['slot']={21, 1, 6, 13, 14},['Shield']=2,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_170.png',['init']=3,['actSet']={'F','TL','BR'}}
-masterPilotDB[171]={['name']='Nashtah Pup',['Faction']= 3,['ship_type']=38,['cost']=6,['slot']={21, 6, 13, 14},['Shield']=2,
+masterPilotDB[171]={['name']='Nashtah Pup',['Faction']= 3,['ship_type']=74,['cost']=6,['slot']={21, 6, 13, 14},['Shield']=2,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png',['init']=0,['actSet']={'F','TL','BR'}}
-masterPilotDB[172]={['name']='Black Sun Soldier',['Faction']= 3,['ship_type']=38,['cost']=24,['slot']={21, 1, 6, 13, 14},['Shield']=2,
+masterPilotDB[172]={['name']='Black Sun Soldier',['Faction']= 3,['ship_type']=74,['cost']=24,['slot']={21, 1, 6, 13, 14},['Shield']=2,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_172.png',['init']=3,['actSet']={'F','TL','BR'}}
-masterPilotDB[173]={['name']='Binayre Pirate',['Faction']= 3,['ship_type']=38,['cost']=22,['slot']={21, 6, 13, 14},['Shield']=2,
+masterPilotDB[173]={['name']='Binayre Pirate',['Faction']= 3,['ship_type']=74,['cost']=22,['slot']={21, 6, 13, 14},['Shield']=2,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_173.png',['init']=1,['actSet']={'F','TL','BR'}}
 masterPilotDB[174]={['name']='Dace Bonearm',['Faction']= 3,['ship_type']=34,['cost']=31,['slot']={21, 1, 8, 12, 13, 14, 14, 15},['Shield']=2,['Charge']=3,
                   ['card']='http://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_174.png',['init']=4,['actSet']={'F','TL','B','Rot'}}
@@ -3058,7 +3061,7 @@ masterPilotDB[643]={
     actSet = {'F','B','TL','BR'}
 }
 
-masterPilotDB[635]={['name']='Bossk',['Faction']= 3,['ship_type']=38,['cost']=29,['slot']={21, 6, 13, 14},['Shield']=2,
+masterPilotDB[635]={['name']='Bossk',['Faction']= 3,['ship_type']=74,['cost']=29,['slot']={21, 6, 13, 14},['Shield']=2,
                   ['card']='http://images-cdn.fantasyflightgames.com/filer_public/d3/9d/d39d7a92-7829-4bc8-ab2c-05843ab3d099/swz66_bossk.png',['init']=4,['actSet']={'F','TL','BR'}}
 masterPilotDB[636]={['name']='G4R-G0R V/M',['Faction']= 3,['ship_type']=44,['cost']=28,['slot']={21, 14,99},['Shield']=1,
                   ['card']='http://images-cdn.fantasyflightgames.com/filer_public/4c/2c/4c2c309f-f9b0-4a93-a3a5-28b43fe981c3/swz66_g4r-g0r_vm.png',['init']=5,['actSet']={'C','E','TL','BR'}}

--- a/TTS_xwing/src/BehaviourDB.ttslua
+++ b/TTS_xwing/src/BehaviourDB.ttslua
@@ -690,3 +690,620 @@ BehaviourDB.rule_sets[1].ships[28].action_selection = {
         ['action'] = 'focus'
     },
 }
+
+-----------------
+-- Rebel Ships --
+-----------------
+
+-- Z-95-AF4 Headhunter
+BehaviourDB.rule_sets[1].ships[38] = {}
+BehaviourDB.rule_sets[1].ships[38].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[38].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k3', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'k3', [4] = 'tr2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k3', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'k3', [5] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [3] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'k3', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [3] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr2'},
+        ['stress'] = {[1] = 's1', [3] = 'br2', [6] = 'tr3'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[38].action_selection = {
+    [1] = { -- Target lock if not in enemy's arc
+        ['description'] = {['text'] = "%s target locked %s outside target's arc.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+        ['action'] = 'targetLock'
+    },
+    [2] = { -- Barrel roll (stress) to avoid target's arc and still get a shot
+        ['description'] = {['text'] = "%s stress barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['hasShot'] = true, ['inTargetsArc'] = true},
+        ['action'] = {['barrelRoll'] = true},
+        ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+    },
+    [3] = { -- Focus if you have a shot
+        ['description'] = "%s has a shot so focused.",
+        ['preconditions'] = {['hasShot'] = true},
+        ['action'] = 'focus'
+    },
+    [4] = { -- Barrel roll (stress) to get a shot
+        ['description'] = "%s stress barrel rolled to get a shot.",
+        ['preconditions'] = {['hasShot'] = false},
+        ['action'] = {['barrelRoll'] = true},
+        ['postconditions'] = {['hasShot'] = true},
+    },
+    [5] = { -- Barrel roll (stress) to avoid target's arc
+        ['description'] = {['text'] = "%s stress barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['inTargetsArc'] = true},
+        ['action'] = {['barrelRoll'] = true},
+        ['postconditions'] = {['inTargetsArc'] = false},
+    },
+    [6] = { -- Focus
+        ['description'] = "%s focused.",
+        ['action'] = 'focus'
+    }
+}
+
+-- T-65 X-Wing
+BehaviourDB.rule_sets[1].ships[33] = {}
+BehaviourDB.rule_sets[1].ships[33].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[33].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'tr3t', [4] = 'tr2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'br1', [3] = 'tr2', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'tr3t', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr3t', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr3t', [4] = 'tr3'},
+        ['stress'] = {[1] = 'br1', [2] = 'tr2', [4] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr3t', [5] = 'tr2'},
+        ['far'] = {[1] = 'tl3t', [3] = 'tr3t'},
+        ['distant'] = {[1] = 'tr3t', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [4] = 'br2', [6] = 'tr3'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[33].action_selection = {
+    [1] = { -- (target not moved) Target lock if not in any arcs
+        ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetMoved'] = false, ['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+        ['action'] = 'targetLock'
+    },
+    [2] = { -- (target moved) Target lock
+        ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = true},
+        ['action'] = 'targetLock'
+    },
+    [3] = { -- (target moved) Barrel roll to avoid target's arc and still get a shot
+        ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = true, ['inTargetsArc'] = true},
+        ['action'] = 'barrelRoll',
+        ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+    },
+    [4] = { -- (target moved) Barrel roll to get a shot
+        ['description'] = "%s barrel rolled to get a shot.",
+        ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+        ['action'] = 'barrelRoll',
+        ['postconditions'] = {['hasShot'] = true},
+    },
+    [5] = { -- (target moved) Barrel roll to avoid target's arc
+        ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetMoved'] = true, ['inTargetsArc'] = true},
+        ['action'] = 'barrelRoll',
+        ['postconditions'] = {['inTargetsArc'] = false},
+    },
+    [6] = { -- Focus
+        ['description'] = "%s focused.",
+        ['action'] = 'focus'
+    }
+}
+
+-- BTL-A4 Y-Wing
+BehaviourDB.rule_sets[1].ships[12] = {}
+BehaviourDB.rule_sets[1].ships[12].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[12].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [2] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [4] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'br1', [5] = 'bl2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's3'},
+        ['stress'] = {[1] = 'br1', [4] = 'br2', [5] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl1', [2] = 'bl2', [5] = 's2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [5] = 'br2', [6] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [5] = 'tr3'},
+        ['stress'] = {[1] = 'br2', [5] = 'tr2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k4', [2] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [3] = 'tr2'},
+        ['distant'] = {[1] = 'tr2', [6] = 'tr3'},
+        ['stress'] = {[1] = 'br1', [4] = 'tr2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 's1', [3] = 'tr2', [5] = 's2'},
+        ['far'] = {[1] = 'br1', [3] = 'tr2'},
+        ['distant'] = {[1] = 'k4', [3] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [4] = 's1', [6] = 'tr2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[12].action_selection = {
+  [1] = { -- Target lock if charges left
+      ['description'] = {['text'] = "%s target locked %s. If %s has no charges on its missile or torpedo upgrades, then undo this action and perform it manually.", ['strings'] = {'ship', 'target', 'ship'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Rotate turret to get a shot
+      ['description'] = "%s rotated its turret to get a shot.",
+      ['preconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = false}},
+      ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = true}},
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Barrel roll (stress) to get a shot
+      ['description'] = "%s barrel rolled to get a shot.",
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['action'] = {['barrelRoll'] = true},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { --  Reload ordnance (stress) if no charges left
+      ['pass_through'] = true,
+      ['description'] = "If %s has no charges on its missile or torpedo upgrades, then undo the following action and take a red reload action.",
+  },
+  [6] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- RZ-1 A-Wing
+BehaviourDB.rule_sets[1].ships[35] = {}
+BehaviourDB.rule_sets[1].ships[35].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[35].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k5', [2] = 'br3s', [4] = 'bl3s', [6] = 's2'},
+        ['far'] = {[1] = 's2', [3] = 's3'},
+        ['distant'] = {[1] = 's4', [2] = 's5'},
+        ['stress'] = {[1] = 's2', [5] = 's3'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl3s', [4] = 'tr1', [5] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'tr2', [2] = 'br2', [5] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k5', [2] = 'bl3s', [4] = 'tr1'},
+        ['far'] = {[1] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2', [6] = 'tr3'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'bl3s', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'br3s', [3] = 'bl3s', [4] = 'tr2'},
+        ['distant'] = {[1] = 'bl3s', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'tr2', [4] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k5', [3] = 'bl3s', [5] = 'tr2'},
+        ['far'] = {[1] = 'bl3s', [3] = 'tr2'},
+        ['distant'] = {[1] = 'bl3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [5] = 'tr3', [6] = 's5'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[35].action_selection = {
+  [1] = { -- (target not moved) Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = false, ['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- (target not moved) Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['targetMoved'] = false, ['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [3] = { -- (target not moved) Evade
+      ['description'] = "%s evaded.",
+      ['preconditions'] = {['targetMoved'] = false, ['evading'] = false},
+      ['action'] = 'evade'
+  },
+  [4] = { -- (target moved) Boost or barrel roll to get a shot
+      ['description'] = "%s barrel rolled/boosted to get a shot.",
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['action'] = {
+          [1] = {['boost'] = false},
+          [2] = {['barrelRoll'] = false}
+      },
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- (target moved) Focus > Boost (stress) to get a shot at range 1
+      ['description'] = "%s focused into a boost (stress) to get a close range shot.",
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = false}},
+      ['action'] = {['focus'] = false, ['boost'] = true},
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = true}},
+  },
+  [6] = { -- (target moved) Barrel roll or boost to avoid target's arc
+      ['description'] = {['text'] = "%s barrel roll/boosted to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['inTargetsArc'] = true},
+      ['action'] = {
+          [1] = {['boost'] = false},
+          [2] = {['barrelRoll'] = false}
+      },
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [7] = { -- (target moved) Target lock if charges left
+      ['description'] = {['text'] = "%s target locked %s. If %s has no charges on its missile upgrade, then undo this action and perform it manually.", ['strings'] = {'ship', 'target', 'ship'}},
+      ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [8] = { -- (target moved) Focus
+      ['description'] = "%s focused.",
+      ['precondition'] = {['targetMoved'] = true},
+      ['action'] = 'focus'
+  }
+}
+
+-- B-Wing
+BehaviourDB.rule_sets[1].ships[17] = {}
+BehaviourDB.rule_sets[1].ships[17].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[17].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k2', [2] = 'br1', [6] = 'bl2'},
+        ['far'] = {[1] = 'br1', [4] = 'br2', [6] = 'br3'},
+        ['distant'] = {[1] = 'br2', [5] = 'br3'},
+        ['stress'] = {[1] = 'br1', [4] = 'br2', [5] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'tr1', [3] = 'br1', [4] = 'tr2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [6] = 'br2'},
+        ['distant'] = {[1] = 'tr2', [4] = 'br2'},
+        ['stress'] = {[1] = 'br1', [5] = 'tr2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k2', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k2', [2] = 'tr1t', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr1t', [3] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [4] = 'tr2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k2', [3] = 'tl1t', [5] = 'tr2'},
+        ['far'] = {[1] = 'k2', [3] = 'tr1t'},
+        ['distant'] = {[1] = 'tr1t', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [5] = 's1', [6] = 's2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[17].action_selection = {
+  [1] = { -- (target not moved) Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = false, ['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- (target moved) Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [3] = { -- (target moved) Focus > barrel roll (stress) to avoid target's arc and still get a shot
+      ['description'] = {['text'] = "%s focused and barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = {['focus'] = false, ['barrelRoll'] = true},
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+  },
+  [4] = { -- (target moved) Focus > barrel roll (stress) to get a shot
+      ['description'] = {['text'] = "%s focused and barrel rolled to get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['action'] = {['focus'] = false, ['barrelRoll'] = true},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- (target moved) Barrel roll to avoid target's arc
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [6] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- YT-2400 Light Freighter
+BehaviourDB.rule_sets[1].ships[12] = {}
+BehaviourDB.rule_sets[1].ships[12].target_selection = {[1]='LockedInRange',  [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[12].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tl2', [5] = 'tr2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [6] = 's3'},
+        ['distant'] = {[1] = 's3', [3] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl1', [3] = 'tl2', [6] = 'bl2'},
+        ['far'] = {[1] = 'br1', [4] = 'br2', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's3'},
+        ['stress'] = {[1] = 'br1', [3] = 's1', [5] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl1', [2] = 'bl2', [4] = 's2'},
+        ['far'] = {[1] = 'tr1', [2] = 'br1', [3] = 'br2', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br1', [6] = 's1'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 's1', [4] = 'bl1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr1', [5] = 'tr2'},
+        ['distant'] = {[1] = 'k4', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br1', [6] = 'tr2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [4] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [3] = 'tr2'},
+        ['distant'] = {[1] = 'tr1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr1', [3] = 'br1'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[12].action_selection = {
+  [1] = { -- Rotate turret if target is not in turret arc
+      ['description'] = "%s rotated its turret to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [2] = { -- (target moved) Target lock if target is in turret arc at range 2
+      ['description'] = "%s target locked target at range 2 in turret arc.",
+      ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = {['arguments'] = {['maxRange'] = 2}, {['minRange'] = 2}, ['requiredResult'] = true}, ['hasShot'] = {['arguments'] = {['maxRange'] = 2}, ['requiredResult'] = true}},
+      ['action'] = 'targetLock'
+  },
+  [3] = { -- (target moved) Barrel roll (stress) to get target at range 2 and in turret arc
+      ['description'] = "%s barrel rolled to get target in turret arc at range 2.",
+      ['preconditions'] = {['targetMoved'] = true, ['targetWithinRange'] = {['arguments'] = {['maxRange'] = 2}, {['minRange'] = 2}, ['requiredResult'] = false}},
+      ['action'] = {['barrelRoll'] = true},
+      ['postconditions'] = {['targetWithinRange'] = {['arguments'] = {['maxRange'] = 2}, {['minRange'] = 2}, ['requiredResult'] = true}, ['hasShot'] = {['arguments'] = {['maxRange'] = 2}, ['requiredResult'] = true}},
+  },
+  [4] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- Modified YT-1300
+BehaviourDB.rule_sets[1].ships[1] = {}
+BehaviourDB.rule_sets[1].ships[1].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[1].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'tl2', [3] = 'tr2', [5] = 'tl3', [6] = 'tr3'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl1', [3] = 'tl2', [6] = 'bl2'},
+        ['far'] = {[1] = 'br1', [4] = 'br2', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [2] = 'bl2', [3] = 'br2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl1', [2] = 'bl2', [4] = 's2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [2] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'bl3s', [3] = 'br1', [4] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'bl3s', [5] = 'tr2'},
+        ['distant'] = {[1] = 'bl3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [3] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr2'},
+        ['far'] = {[1] = 'br3s', [3] = 'bl3s'},
+        ['distant'] = {[1] = 'bl3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[1].action_selection = {
+  [1] = { -- Rotate turret if target is not in turret arc
+      ['description'] = "%s rotated its turret to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [2] = { -- Boost (stress) to get a shot
+      ['description'] = "%s boosted to get a shot.",
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['action'] = {['boost'] = true},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [3] = { -- Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [4] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- VCX-100
+BehaviourDB.rule_sets[1].ships[23] = {}
+BehaviourDB.rule_sets[1].ships[23].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[23].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [2] = 's1', [3] = 'tl2', [5] = 'tr2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'br1', [3] = 'bl2', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [2] = 'bl2', [3] = 'br2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'bl2', [4] = 'tr2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [4] = 'br2', [6] = 'tr3'},
+        ['distant'] = {[1] = 'tr1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [2] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k4', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr1', [3] = 'tr2'},
+        ['distant'] = {[1] = 'k4', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [3] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tl2', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [3] = 'tr2'},
+        ['distant'] = {[1] = 'k4', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[23].action_selection = {
+  [1] = { -- Rotate turret to get a shot
+      ['description'] = "%s rotated its turret to get a shot.",
+      ['preconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = false}},
+      ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = true}},
+  },
+  [2] = { -- Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Reinforce the fore if target is within that full arc
+      ['description'] = "%s reinforced fore.",
+      ['preconditions'] = {['inTargetsArc'] = {['arguments'] = {['arc'] = 'fullfront'}, ['requiredResult'] = true}},
+      ['action'] = 'reinforceFore'
+  },
+  [5] = { -- Reinforce the aft if within arc of two or more enemies in that full arc
+      ['description'] = "%s reinforced aft.",
+      ['preconditions'] = {['inTargetsArc'] = {['arguments'] = {['arc'] = 'fullback'}, ['requiredResult'] = true}},
+      ['action'] = 'reinforceAft'
+  },
+  [6] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+----------------
+-- Scum Ships --
+----------------
+
+-- Z-95-AF4 Headhunter
+BehaviourDB.rule_sets[1].ships[74] = {}
+BehaviourDB.rule_sets[1].ships[74].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[74].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k3', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'k3', [4] = 'tr2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k3', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'k3', [5] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [3] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'k3', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [3] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr2'},
+        ['stress'] = {[1] = 's1', [3] = 'br2', [6] = 'tr3'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[74].action_selection = {
+    [1] = { -- Target lock if not in enemy's arc
+        ['description'] = {['text'] = "%s target locked %s outside target's arc.", ['strings'] = {'ship', 'target'}},
+        ['preconditions'] = {['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+        ['action'] = 'targetLock'
+    },
+    [2] = { -- Focus if you have a shot
+        ['description'] = "%s has a shot so focused.",
+        ['preconditions'] = {['hasShot'] = true},
+        ['action'] = 'focus'
+    },
+    [3] = { -- Barrel roll (stress) to get a shot
+        ['description'] = "%s stress barrel rolled to get a shot.",
+        ['preconditions'] = {['hasShot'] = false},
+        ['action'] = {['barrelRoll'] = true},
+        ['postconditions'] = {['hasShot'] = true},
+    },
+    [4] = { -- Focus
+        ['description'] = "%s focused.",
+        ['action'] = 'focus'
+    }
+}

--- a/TTS_xwing/src/BehaviourDB.ttslua
+++ b/TTS_xwing/src/BehaviourDB.ttslua
@@ -889,7 +889,7 @@ BehaviourDB.rule_sets[1].ships[12].action_selection = {
   },
   [4] = { -- Barrel roll (stress) to get a shot
       ['description'] = "%s barrel rolled to get a shot.",
-      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['preconditions'] = {['hasShot'] = false},
       ['action'] = {['barrelRoll'] = true},
       ['postconditions'] = {['hasShot'] = true},
   },
@@ -1061,9 +1061,9 @@ BehaviourDB.rule_sets[1].ships[17].action_selection = {
 }
 
 -- YT-2400 Light Freighter
-BehaviourDB.rule_sets[1].ships[12] = {}
-BehaviourDB.rule_sets[1].ships[12].target_selection = {[1]='LockedInRange',  [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
-BehaviourDB.rule_sets[1].ships[12].move_table = {
+BehaviourDB.rule_sets[1].ships[5] = {}
+BehaviourDB.rule_sets[1].ships[5].target_selection = {[1]='LockedInRange',  [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[5].move_table = {
     ['bullseye'] = {
         ['near'] = {[1] = 'k4', [3] = 'tl2', [5] = 'tr2'},
         ['far'] = {[1] = 's1', [2] = 's2', [6] = 's3'},
@@ -1095,7 +1095,7 @@ BehaviourDB.rule_sets[1].ships[12].move_table = {
         ['stress'] = {[1] = 'tr1', [3] = 'br1'},
     },
 }
-BehaviourDB.rule_sets[1].ships[12].action_selection = {
+BehaviourDB.rule_sets[1].ships[5].action_selection = {
   [1] = { -- Rotate turret if target is not in turret arc
       ['description'] = "%s rotated its turret to get a shot.",
       ['preconditions'] = {['hasShot'] = false},
@@ -1216,9 +1216,9 @@ BehaviourDB.rule_sets[1].ships[23].move_table = {
 BehaviourDB.rule_sets[1].ships[23].action_selection = {
   [1] = { -- Rotate turret to get a shot
       ['description'] = "%s rotated its turret to get a shot.",
-      ['preconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = false}},
+      ['preconditions'] = {['hasShot'] = false},
       ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
-      ['postconditions'] = {['hasShot'] = {['arguments'] = {['includeArcs'] = {'front'}}, ['requiredResult'] = true}},
+      ['postconditions'] = {['hasShot'] = true},
   },
   [2] = { -- Target lock
       ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
@@ -1306,4 +1306,638 @@ BehaviourDB.rule_sets[1].ships[74].action_selection = {
         ['description'] = "%s focused.",
         ['action'] = 'focus'
     }
+}
+
+-- M3-A Interceptor
+BehaviourDB.rule_sets[1].ships[44] = {}
+BehaviourDB.rule_sets[1].ships[44].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[44].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k5', [3] = 'k3', [5] = 'bl1', [6] = 'br1'},
+        ['far'] = {[1] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's4', [2] = 's5'},
+        ['stress'] = {[1] = 's2', [5] = 's3'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k3', [4] = 'tr1', [6] = 'br1'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [4] = 's2', [6] = 's3'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k5', [3] = 'tr1', [6] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [2] = 'br1', [3] = 'tr2', [6] = 'br2'},
+        ['distant'] = {[1] = 'tr1', [3] = 'tr2'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br1'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k5', [2] = 'k3', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [3] = 'tr1', [5] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [3] = 'br1'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k5', [3] = 'k3', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [4] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [5] = 'tr1'},
+        ['stress'] = {[1] = 'br1', [3] = 'tr2', [5] = 's3'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[44].action_selection = {
+  [1] = { -- Target lock if charges left
+      ['description'] = {['text'] = "%s target locked %s. If %s has no charges on its missile or torpedo upgrades, then undo this action and perform it manually.", ['strings'] = {'ship', 'target', 'ship'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Barrel roll to get a shot
+      ['description'] = "%s stress barrel rolled to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {['barrelRoll'] = false},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Evade
+      ['description'] = "%s evades.",
+      ['action'] = 'evade'
+  }
+}
+
+-- Khiraxz Fighter
+BehaviourDB.rule_sets[1].ships[7] = {}
+BehaviourDB.rule_sets[1].ships[7].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[7].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 'bl1', [5] = 'br1'},
+        ['far'] = {[1] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's2', [5] = 's3'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [4] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'tr2t', [4] = 'tr1'},
+        ['far'] = {[1] = 'tr1', [2] = 'br1', [3] = 'br2', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr1', [3] = 'br1', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr2t', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr2t', [5] = 'tr1'},
+        ['distant'] = {[1] = 'tr2t', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br1', [4] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr2t', [5] = 'tr2'},
+        ['far'] = {[1] = 'tl2t', [3] = 'tr2t'},
+        ['distant'] = {[1] = 'tr2t', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br1', [4] = 'br2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[7].action_selection = {
+  [1] = { -- (target not moved) Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = false, ['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- (target moved) Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [3] = { -- (target moved) Barrel roll to avoid target's arc and still get a shot
+      ['description'] = {['text'] = "%s focused and barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = {['barrelRoll'] = false},
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+  },
+  [4] = { -- (target moved) Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [5] = { -- (target moved) Barrel roll to avoid target's arc
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [6] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- StarViper
+BehaviourDB.rule_sets[1].ships[3] = {}
+BehaviourDB.rule_sets[1].ships[3].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[3].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'br3s', [2] = 'bl3s', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl3s', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl3s', [3] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [2] = 'tr2', [6] = 'br2'},
+        ['distant'] = {[1] = 'tr1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [3] = 'tr2', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'bl3s', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'br3s', [2] = 'bl3s', [5] = 'tr2'},
+        ['distant'] = {[1] = 'br3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [2] = 'tr2', [4] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'br3s', [3] = 'bl3s', [5] = 'tr1'},
+        ['far'] = {[1] = 'br3s', [3] = 'bl3s'},
+        ['distant'] = {[1] = 'br3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [4] = 'tr2', [5] = 'br2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[3].action_selection = {
+  [1] = { -- Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Boost or barrel roll > Focus (stress) to avoid Target arc and still get a shot
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to avoid target's arc and still get a shot.",
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = {
+        [1] = {['boost'] = false, ['focus'] = true},
+        [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false},
+  },
+  [3] = { -- Boost or barrel roll > Focus (stress) to get a shot at range 1
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to get a close range shot.",
+      ['preconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = false}},
+      ['action'] = {
+        [1] = {['boost'] = false, ['focus'] = true},
+        [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = true}},
+  },
+  [4] = { -- Boost or barrel roll > Focus (stress) to get a shot
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {
+        [1] = {['boost'] = false, ['focus'] = true},
+        [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- Barrel roll or boost to avoid target's arc
+      ['description'] = {['text'] = "%s barrel roll/boosted to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = {
+        [1] = {['boost'] = false},
+        [2] = {['barrelRoll'] = false}
+      },
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [6] = { -- (target moved) Focus
+      ['description'] = "%s focused.",
+      ['precondition'] = {['targetMoved'] = true},
+      ['action'] = 'focus'
+  }
+}
+
+-- Fang Fighter
+BehaviourDB.rule_sets[1].ships[36] = {}
+BehaviourDB.rule_sets[1].ships[36].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
+BehaviourDB.rule_sets[1].ships[36].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 'bl2', [4] = 'br2', [5] = 's2'},
+        ['far'] = {[1] = 's2', [4] = 's3'},
+        ['distant'] = {[1] = 's4', [2] = 's5'},
+        ['stress'] = {[1] = 'bl2', [2] = 'br2', [3] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr1', [5] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br2', [4] = 's2', [5] = 's3'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [2] = 'tr2', [4] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr2t', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr2t', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr2t', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr2', [5] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'tl2t', [3] = 'tr2t', [5] = 'tr2'},
+        ['far'] = {[1] = 'tl2t', [3] = 'tr2t'},
+        ['distant'] = {[1] = 'tr2t', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr2', [4] = 'br2', [6] = 's2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[36].action_selection = {
+  [1] = { -- Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Boost or barrel roll > Focus (stress) to avoid Target arc and still get a shot
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to avoid target's arc and still get a shot.",
+      ['preconditions'] = {['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = {
+          [1] = {['boost'] = false, ['focus'] = true},
+          [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false},
+  },
+  [3] = { -- Boost or barrel roll > Focus (stress) to get a shot at range 1
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to get a close range shot.",
+      ['preconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = false}},
+      ['action'] = {
+          [1] = {['boost'] = false, ['focus'] = true},
+          [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = true}},
+  },
+  [4] = { -- Boost or barrel roll > Focus (stress) to get a shot
+      ['description'] = "%s barrel rolled/boosted into a focus (stress) to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {
+          [1] = {['boost'] = false, ['focus'] = true},
+          [2] = {['barrelRoll'] = false, ['focus'] = true}
+      },
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- Barrel roll or boost to avoid target's arc
+      ['description'] = {['text'] = "%s barrel roll/boosted to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = {
+          [1] = {['boost'] = false},
+          [2] = {['barrelRoll'] = false}
+      },
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [6] = { -- (target moved) Focus
+      ['description'] = "%s focused.",
+      ['precondition'] = {['targetMoved'] = true},
+      ['action'] = 'focus'
+  }
+}
+
+-- HWK-290 Light Freighter
+---- This logic is shared between Scum and Rebel. See Z-95 for an example on how to split them if necessary.
+BehaviourDB.rule_sets[1].ships[34] = {}
+BehaviourDB.rule_sets[1].ships[34].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[34].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 's0', [4] = 'bl1', [5] = 'br1', [6] = 's1'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 's0', [3] = 's1', [5] = 'br1', [6] = 'tl2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl1', [2] = 'tr2', [4] = 'bl2'},
+        ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'br1', [6] = 'tr2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 's0', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'br1', [3] = 'tr2'},
+        ['distant'] = {[1] = 'br1', [3] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [5] = 'tr2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 's0', [3] = 'br1', [5] = 'tr2', [6] = 'br3'},
+        ['far'] = {[1] = 'br1', [3] = 'tr2'},
+        ['distant'] = {[1] = 'br1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [5] = 's1', [6] = 'tr2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[34].action_selection = {
+  [1] = { -- Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Rotate turret to get a shot
+      ['description'] = "%s rotated its turret to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {['rotateTurret'] = {['mount'] = 'main'}},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [3] = { -- Boost (stress) to get a shot
+      ['description'] = "%s boosted to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = {['boost'] = true},
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [4] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- Firespray-Class Patrol Craft
+BehaviourDB.rule_sets[1].ships[10] = {}
+BehaviourDB.rule_sets[1].ships[10].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[10].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's1', [2] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's3', [2] = 's4'},
+        ['stress'] = {[1] = 's1', [4] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 's1', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [2] = 'tr3t', [4] = 'tr1'},
+        ['far'] = {[1] = 'tr1', [3] = 'br1', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr1', [4] = 'tr2'},
+        ['stress'] = {[1] = 'tr1', [2] = 'bl1', [4] = 'br1'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'tr3t', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'tr3t', [5] = 'tr2'},
+        ['distant'] = {[1] = 'tr3t', [4] = 'tr2'},
+        ['stress'] = {[1] = 'bl1', [3] = 'br1', [5] = 'tr2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'tr3t', [5] = 'tr2'},
+        ['far'] = {[1] = 'tl3t', [3] = 'tr3t'},
+        ['distant'] = {[1] = 'tr3t', [4] = 'tr2'},
+        ['stress'] = {[1] = 'bl1', [3] = 'br1', [6] = 'tr2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[10].action_selection = {
+  [1] = { -- (target not moved) Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = false, ['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- (target moved) Target lock
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['targetLocked'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [3] = { -- (target moved) Boost to get a shot
+      ['description'] = {['text'] = "%s boosted to get a shot.", ['strings'] = {'ship'}},
+      ['preconditions'] = {['targetMoved'] = true, ['hasShot'] = false},
+      ['action'] = {['boost'] = false},
+      ['postconditions'] = {['hasShot'] = true}
+  },
+  [4] = { -- (target moved) Boost to get within Range 1 and still get a shot
+      ['description'] = "%s boosted to get a close range shot.",
+      ['preconditions'] = {['hasShot'] = {['arguments'] = {['minRange'] = 2}, ['requiredResult'] = true}},
+      ['action'] = {['boost'] = false},
+      ['postconditions'] = {['hasShot'] = {['arguments'] = {['maxRange'] = 1}, ['requiredResult'] = true}},
+  },
+  [5] = { -- (target moved) Boost to avoid target's arc
+      ['description'] = {['text'] = "%s boosted to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetMoved'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'boost',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [6] = { -- Focus
+      ['description'] = "%s focused.",
+      ['action'] = 'focus'
+  }
+}
+
+-- Modified TIE/Ln Fighter (Mining Guild)
+BehaviourDB.rule_sets[1].ships[56] = {}
+BehaviourDB.rule_sets[1].ships[56].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
+BehaviourDB.rule_sets[1].ships[56].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k3', [3] = 'bl2', [4] = 'br2', [5] = 's2'},
+        ['far'] = {[1] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's4', [6] = 's5'},
+        ['stress'] = {[1] = 'bl2', [3] = 'br2', [5] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'k3', [3] = 'tr1', [5] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br2', [4] = 's2', [6] = 's3'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k3', [2] = 'tr1', [4] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr1', [2] = 'br2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'k3', [2] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [3] = 'tr1', [5] = 'tr2'},
+        ['distant'] = {[1] = 'k3', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k3', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k3', [3] = 'tr1', [4] = 'tr3'},
+        ['distant'] = {[1] = 'k3', [5] = 'tr1'},
+        ['stress'] = {[1] = 'br2', [6] = 'tr3'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[56].action_selection = {
+  [1] = { -- Barrel roll to avoid target's arc and still get a shot
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+  },
+  [2] = { -- Barrel roll to get a shot
+      ['description'] = "%s barrel rolled to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Barrel roll to avoid target's arc
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [5] = { -- Evade
+      ['description'] = "%s evades.",
+      ['action'] = 'evade'
+  }
+}
+
+--------------
+-- FO Ships --
+--------------
+
+-- TIE/fo Fighter
+BehaviourDB.rule_sets[1].ships[49] = {}
+BehaviourDB.rule_sets[1].ships[49].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[49].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'k4', [3] = 'bl2', [4] = 'br2', [5] = 's2'},
+        ['far'] = {[1] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's4', [2] = 's5'},
+        ['stress'] = {[1] = 'bl2', [3] = 'br2', [5] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl2s', [3] = 'tr1', [5] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br2', [4] = 's2', [6] = 's3'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'k4', [3] = 'bl2s', [5] = 'tr1'},
+        ['far'] = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'tr1', [2] = 'tr2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'bl2s', [4] = 'tr1', [5] = 'tr2'},
+        ['far'] = {[1] = 'k4', [2] = 'bl2s', [5] = 'tr2'},
+        ['distant'] = {[1] = 'bl2s', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tr1', [2] = 'tr2', [6] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'k4', [3] = 'bl2s', [5] = 'tr2'},
+        ['far'] = {[1] = 'br2s', [3] = 'bl2s'},
+        ['distant'] = {[1] = 'bl2s', [4] = 'tr1'},
+        ['stress'] = {[1] = 'tl2', [4] = 'tr2', [6] = 's4'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[49].action_selection = {
+  [1] = { -- Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Barrel roll to avoid target's arc and still get a shot
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Barrel roll to get a shot
+      ['description'] = "%s barrel rolled to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- Barrel roll to avoid target's arc
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [5] = { -- Evade
+      ['description'] = "%s evades.",
+      ['action'] = 'evade'
+  }
+}
+
+-- TIE/sf Fighter
+BehaviourDB.rule_sets[1].ships[50] = {}
+BehaviourDB.rule_sets[1].ships[50].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[50].move_table = {
+    ['bullseye'] = {
+        ['near'] = {[1] = 'br3s', [2] = 'bl3s', [3] = 's1', [5] = 's2'},
+        ['far'] = {[1] = 's2', [5] = 's3'},
+        ['distant'] = {[1] = 's4', [2] = 's5'},
+        ['stress'] = {[1] = 'bl1', [3] = 'br1', [5] = 's2'},
+    },
+    ['front_right'] = {
+        ['near'] = {[1] = 'bl3s', [3] = 'br1', [6] = 'br2'},
+        ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+        ['distant'] = {[1] = 'br3', [5] = 's4'},
+        ['stress'] = {[1] = 'br1', [4] = 'br2', [6] = 's3'},
+    },
+    ['right_front'] = {
+        ['near'] = {[1] = 'bl3s', [3] = 'tr1', [4] = 'tr2'},
+        ['far'] = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
+        ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
+        ['stress'] = {[1] = 'br1', [5] = 'tr2'},
+    },
+    ['right_back'] = {
+        ['near'] = {[1] = 'bl3s', [4] = 'br1', [5] = 'tr2'},
+        ['far'] = {[1] = 'br3s', [2] = 'bl3s', [5] = 'tr2'},
+        ['distant'] = {[1] = 'br3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [2] = 'tr2', [4] = 'br2'},
+    },
+    ['back_right'] = {
+        ['near'] = {[1] = 'br3s', [3] = 'bl3s', [5] = 'tr2'},
+        ['far'] = {[1] = 'br3s', [3] = 'bl3s'},
+        ['distant'] = {[1] = 'br3s', [4] = 'tr2'},
+        ['stress'] = {[1] = 'br1', [4] = 'tr2', [5] = 'br2'},
+    },
+}
+BehaviourDB.rule_sets[1].ships[50].action_selection = {
+  [1] = { -- Target lock if not in any arcs
+      ['description'] = {['text'] = "%s target locked %s.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['targetLocked'] = false, ['inEnemyArc'] = false, ['targetWithinRange'] = true},
+      ['action'] = 'targetLock'
+  },
+  [2] = { -- Barrel roll to avoid target's arc and still get a shot
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc and still get a shot.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['hasShot'] = true, ['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true, ['inTargetsArc'] = false}
+  },
+  [3] = { -- Focus if you have a shot
+      ['description'] = "%s has a shot so focused.",
+      ['preconditions'] = {['hasShot'] = true},
+      ['action'] = 'focus'
+  },
+  [4] = { -- Barrel roll to get a shot
+      ['description'] = "%s barrel rolled to get a shot.",
+      ['preconditions'] = {['hasShot'] = false},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['hasShot'] = true},
+  },
+  [5] = { -- Barrel roll to avoid target's arc
+      ['description'] = {['text'] = "%s barrel rolled to avoid %s's arc.", ['strings'] = {'ship', 'target'}},
+      ['preconditions'] = {['inTargetsArc'] = true},
+      ['action'] = 'barrelRoll',
+      ['postconditions'] = {['inTargetsArc'] = false},
+  },
+  [5] = { -- Evade
+      ['description'] = "%s evades.",
+      ['action'] = 'evade'
+  }
 }


### PR DESCRIPTION
Rebel ships:
Z-95 Headhunter,
T-65 X-Wing,
STL-A4 Y-Wing (this also works for Scum version),
RZ-1 A-Wing,
A/SF-01 B-Wing,
YT-2400 Light Freighter,
Modified YT-1300,
VCX-100

Scum ships:
Z-95 Headhunter (slightly different AI from Rebel - less evasive),
M3-A Interceptor,
Kihraxz Fighter,
StarViper,
Fang Fighter,
HWK-290 Light Freighter (this also work for Rebel version),
Firespray-Class Patrol Craft,
Modified TIE/Ln Fighter (Mining Guild),

First Order ships:
TIE/fo Fighter,
TIE/sf Fighter